### PR TITLE
Make sure command list page is under 2000 characters

### DIFF
--- a/src/main/java/net/dirtydeeds/discordsoundboard/listeners/ChatSoundBoardListener.java
+++ b/src/main/java/net/dirtydeeds/discordsoundboard/listeners/ChatSoundBoardListener.java
@@ -357,13 +357,13 @@ public class ChatSoundBoardListener extends ListenerAdapter {
         String[] tokens = commandString.toString().split(SPLIT_REGEXP);
         int lineLen = 0;
         StringBuilder output = new StringBuilder();
-        output.append("```\n");
+        output.append("```");
         for (int i = 0; i < tokens.length; i++) {
             String word = tokens[i];
 
             if (lineLen + (word).length() > maxLineLength) {
                 if (i > 0) {
-                    output.append("```\n");
+                    output.append("```");
                     soundFiles.add(output.toString());
 
                     output = new StringBuilder(maxLineLength);


### PR DESCRIPTION
I have a soundboard with more than 1 page, but I was unable to call "?list 1" because of this error:

```
java.lang.IllegalArgumentException: Provided text for message must be less than 2000 characters in length
        at net.dv8tion.jda.core.utils.Checks.check(Checks.java:27) ~[classes!/:2.2.2-beta]
        at net.dv8tion.jda.core.entities.MessageChannel.sendMessage(MessageChannel.java:191) ~[classes!/:2.2.2-beta]
        at net.dirtydeeds.discordsoundboard.service.SoundPlayerImpl.sendPrivateMessage(SoundPlayerImpl.java:384) ~[classes!/:2.2.2-beta]
        at net.dirtydeeds.discordsoundboard.listeners.ChatSoundBoardListener.replyByPrivateMessage(ChatSoundBoardListener.java:398) ~[classes!/:2.2.2-beta]
        at net.dirtydeeds.discordsoundboard.listeners.ChatSoundBoardListener.onMessageReceived(ChatSoundBoardListener.java:98) ~[classes!/:2.2.2-beta]
        at net.dv8tion.jda.core.hooks.ListenerAdapter.onEvent(ListenerAdapter.java:404) ~[classes!/:2.2.2-beta]
        at net.dv8tion.jda.core.hooks.InterfacedEventManager.handle(InterfacedEventManager.java:84) ~[classes!/:2.2.2-beta]
        at net.dv8tion.jda.core.handle.MessageCreateHandler.handleDefaultMessage(MessageCreateHandler.java:128) [classes!/:2.2.2-beta]
        at net.dv8tion.jda.core.handle.MessageCreateHandler.handleInternally(MessageCreateHandler.java:49) [classes!/:2.2.2-beta]
        at net.dv8tion.jda.core.handle.SocketHandler.handle(SocketHandler.java:37) [classes!/:2.2.2-beta]
        at net.dv8tion.jda.core.requests.WebSocketClient.handleEvent(WebSocketClient.java:969) [classes!/:2.2.2-beta]
        at net.dv8tion.jda.core.requests.WebSocketClient.onTextMessage(WebSocketClient.java:661) [classes!/:2.2.2-beta]
        at com.neovisionaries.ws.client.ListenerManager.callOnTextMessage(ListenerManager.java:352) [classes!/:2.2.2-beta]
        at com.neovisionaries.ws.client.ReadingThread.callOnTextMessage(ReadingThread.java:260) [classes!/:2.2.2-beta]
        at com.neovisionaries.ws.client.ReadingThread.callOnTextMessage(ReadingThread.java:238) [classes!/:2.2.2-beta]
        at com.neovisionaries.ws.client.ReadingThread.handleTextFrame(ReadingThread.java:963) [classes!/:2.2.2-beta]
        at com.neovisionaries.ws.client.ReadingThread.handleFrame(ReadingThread.java:746) [classes!/:2.2.2-beta]
        at com.neovisionaries.ws.client.ReadingThread.main(ReadingThread.java:108) [classes!/:2.2.2-beta]
        at com.neovisionaries.ws.client.ReadingThread.runMain(ReadingThread.java:64) [classes!/:2.2.2-beta]
        at com.neovisionaries.ws.client.WebSocketThread.run(WebSocketThread.java:45) [classes!/:2.2.2-beta]

```
If anyone else gets this, the immediate workaround is to lower the message_size_limit to 1993 in app.properties.

The problem is that the messageSizeLimit variable is 1994, which accounts for the backticks added to the message, but the newlines isn't accounted for.

As I see it, there is no need to add the newlines.