### PR TITLE
Update to Spring Boot 2.0.3 and others

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,8 +34,8 @@ repositories {
 
 dependencies {
     //https://bintray.com/dv8fromtheworld/maven/JDA
-    compile 'net.dv8tion:JDA:3.6.0_354'
-    compile 'com.sedmelluq:lavaplayer:1.2.63'
+    compile 'net.dv8tion:JDA:3.7.1_386'
+    compile 'com.sedmelluq:lavaplayer:1.3.7'
     compile 'commons-io:commons-io:2.4'
 
     compile 'org.springframework.boot:spring-boot-starter-web'

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'java'
 apply plugin: 'idea'
 apply plugin: 'distribution'
 apply plugin: 'org.springframework.boot'
+apply plugin: 'io.spring.dependency-management'
 
 version = '2.2.5-beta'
 
@@ -12,7 +13,7 @@ targetCompatibility = 1.8
 
 buildscript {
     ext {
-        springBootVersion = '1.5.7.RELEASE'
+        springBootVersion = '2.0.3.RELEASE'
     }
     repositories {
         mavenCentral()

--- a/src/main/java/net/dirtydeeds/discordsoundboard/AudioPlayerSendHandler.java
+++ b/src/main/java/net/dirtydeeds/discordsoundboard/AudioPlayerSendHandler.java
@@ -30,7 +30,7 @@ public class AudioPlayerSendHandler implements AudioSendHandler {
             lastFrame = audioPlayer.provide();
         }
 
-        byte[] data = lastFrame != null ? lastFrame.data : null;
+        byte[] data = lastFrame != null ? lastFrame.getData() : null;
         lastFrame = null;
 
         return data;

--- a/src/main/java/net/dirtydeeds/discordsoundboard/listeners/EntranceSoundBoardListener.java
+++ b/src/main/java/net/dirtydeeds/discordsoundboard/listeners/EntranceSoundBoardListener.java
@@ -10,7 +10,8 @@ import net.dv8tion.jda.core.events.guild.voice.GenericGuildVoiceEvent;
 import net.dv8tion.jda.core.events.guild.voice.GuildVoiceJoinEvent;
 import net.dv8tion.jda.core.events.guild.voice.GuildVoiceMoveEvent;
 import net.dv8tion.jda.core.hooks.ListenerAdapter;
-import org.apache.commons.logging.impl.SimpleLog;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author asafatli.
@@ -19,7 +20,7 @@ import org.apache.commons.logging.impl.SimpleLog;
  */
 public class EntranceSoundBoardListener extends ListenerAdapter {
 
-    private static final SimpleLog LOG = new SimpleLog("EntranceListener");
+    private static final Logger log = LoggerFactory.getLogger(EntranceSoundBoardListener.class);
 
     private SoundPlayerImpl bot;
 
@@ -56,10 +57,10 @@ public class EntranceSoundBoardListener extends ListenerAdapter {
                     try {
                         bot.playFileForEntrance(fileToPlay, event, channel);
                     } catch (Exception e) {
-                        LOG.fatal("Could not play file for entrance of " + joined);
+                        log.error("Could not play file for entrance of {}", joined);
                     }
                 } else {
-                    LOG.info("Could not find any sound that starts with " + joined + ", so ignoring entrance.");
+                    log.info("Could not find any sound that starts with {}, so ignoring entrance.", joined);
                 }
             }
         }

--- a/src/main/java/net/dirtydeeds/discordsoundboard/listeners/LeaveSoundBoardListener.java
+++ b/src/main/java/net/dirtydeeds/discordsoundboard/listeners/LeaveSoundBoardListener.java
@@ -4,7 +4,8 @@ import net.dirtydeeds.discordsoundboard.beans.SoundFile;
 import net.dirtydeeds.discordsoundboard.service.SoundPlayerImpl;
 import net.dv8tion.jda.core.events.guild.voice.GuildVoiceLeaveEvent;
 import net.dv8tion.jda.core.hooks.ListenerAdapter;
-import org.apache.commons.logging.impl.SimpleLog;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 import java.util.Set;
@@ -16,7 +17,7 @@ import java.util.Set;
  */
 public class LeaveSoundBoardListener extends ListenerAdapter {
 
-    private static final SimpleLog LOG = new SimpleLog("LeaveListener");
+    private static final Logger log = LoggerFactory.getLogger(LeaveSoundBoardListener.class);
 
     private SoundPlayerImpl bot;
     private String suffix = "_leave";
@@ -48,10 +49,10 @@ public class LeaveSoundBoardListener extends ListenerAdapter {
                     try {
                         bot.playFileForDisconnect(fileToPlay, event);
                     } catch (Exception e) {
-                        LOG.fatal("Could not play file for disconnection of " + userDisconnected);
+                        log.error("Could not play file for disconnection of {}", userDisconnected);
                     }
                 } else {
-                    LOG.info("Could not disconnection sound for " + userDisconnected + ", so ignoring disconnection event.");
+                    log.info("Could not disconnection sound for {}, so ignoring disconnection event.", userDisconnected);
                 }
             }
         }

--- a/src/main/java/net/dirtydeeds/discordsoundboard/repository/SoundFileRepository.java
+++ b/src/main/java/net/dirtydeeds/discordsoundboard/repository/SoundFileRepository.java
@@ -23,7 +23,7 @@ public interface SoundFileRepository extends CrudRepository<SoundFile, String> {
         long count = count();
         int random = (int) (Math.random() * count);
 
-        Page<SoundFile> page = findAll(new PageRequest(random, 1));
+        Page<SoundFile> page = findAll(PageRequest.of(random, 1));
 
         if (page.hasContent()) {
             return page.getContent().get(0);


### PR DESCRIPTION
Basically I just wanted to bump Spring Boot to 2 in order to get access to hibernate 5.2, but I figured it's good to keep up to date with other libraries as well.

Version bumps for:

Spring Boot 1.5.7 -> 2.0.3
JDA 3.6.0_354 -> 3.7.1_386
LavaPlayer 1.2.63 -> 1.3.7

Also replaced some apache logging code with slf4j.