### PR TITLE
More dependency updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,8 +42,8 @@ repositories {
 }
 
 dependencies {
-    compile 'net.dv8tion:JDA:4.2.0_212'
-    compile 'com.sedmelluq:lavaplayer:1.3.53'
+    compile 'net.dv8tion:JDA:4.2.0_214'
+    compile 'com.sedmelluq:lavaplayer:1.3.55'
     //compile 'lavaplayer-natives-extra:1.3.13'
     compile 'commons-io:commons-io:2.8.0'
 


### PR DESCRIPTION
JDA and lavaplayer have been updating pretty frequently over the last week. I found that on my bot, with the round of dependency updates prior to this one, YouTube videos had stopped playing after a day or two. Updating to these new versions seems to have fixed the issue.