### PR TITLE
Update ChatSoundBoardListener.java

### DIFF
--- a/src/main/java/net/dirtydeeds/discordsoundboard/ChatSoundBoardListener.java
+++ b/src/main/java/net/dirtydeeds/discordsoundboard/ChatSoundBoardListener.java
@@ -424,8 +424,8 @@ public class ChatSoundBoardListener extends ListenerAdapter {
             if (commandString.length() > maxLineLength) {
                 replyByPrivateMessage(event, "You have " + soundList.size() + " pages of soundFiles. Reply: ```" + commandCharacter + "list pageNumber``` to request a specific page of results.");
             } else {
-                replyByPrivateMessage(event, "Type any of the following into the chat to play the sound:");
-                replyByPrivateMessage(event, soundList.get(0));
+                replyByPrivateMessage(event, "Type any of the following into the chat to play the sound:"+
+				"\n"+soundList.get(0));
             }
         } else {
             String[] messageSplit = message.split(" ");


### PR DESCRIPTION
two consecutive replyByPrivateMessage provoke an Exception because both try to delete the original command.

fixes #155 