### PR TITLE
Docker compose README and docker-entrypoint updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,31 @@ https://github.com/Darkside138/DiscordSoundboard/wiki
 Smugaloof has made a great setup video you can watch [here](https://www.youtube.com/watch?v=DQSXP9AgYvw). 
 This will walk you through the process of getting your bot up and running.
 
+### Docker Setup
+Dockerhub image source: https://hub.docker.com/r/davefurrer/discordsoundboard
+
+Using docker compose:
+```
+---
+services:
+  discordsoundbot:
+    image: davefurrer/discordsoundboard:latest
+    container_name: DiscordSoundbot
+    environment:
+      - bottoken=<Insert bot token here>
+      - username=<Insert Discord username here>
+      - chatcommands=true
+      - dm=true
+      - commandcharacter=?
+      - sizelimit=2000
+      - leavesuffix=_leave
+    ports:
+      - 8080:8080
+    volumes:
+      - <full/path/to/sounds/directory>:/etc/DiscordSoundboard/bin/sounds
+    restart: unless-stopped
+```
+
 ## Setting correct permissions on your discord bot
 To fix the issue of being stuck on "Connecting to websocket":
 Login to your Discord Developer Portal and enable Privileged Intents for your bot. Go to https://discord.com/developers/applications select your bot, click Bot on the left, and then enable both of the sliders under Privileged Gateway Intents.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ services:
     ports:
       - 8080:8080
     volumes:
-      - <full/path/to/sounds/directory>:/etc/DiscordSoundboard/bin/sounds
+      - /path/to/sounds/directory:/etc/DiscordSoundboard/bin/sounds
     restart: unless-stopped
 ```
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -13,6 +13,7 @@ cd /etc/DiscordSoundboard/config
 #Overwrite the bottoken and username to join channel config entries from environment variables passed into docker run
 sed -i 's/bot_token=SOME_TOKEN_YOU_GOT_FROM_DISCORD/bot_token='$bottoken'/g' application.properties
 sed -i 's/username_to_join_channel=YourUserName/username_to_join_channel='$username'/g' application.properties
+sed -i 's/command_character=?/command_character='$commandcharacter'/g' application.properties
 
 cd /etc/DiscordSoundboard/bin
 


### PR DESCRIPTION
Changes:
1. Command character is now passed to the container when set as an environment variable
2. README updated with docker compose instructions

Changes were tested on a local build of the image: https://hub.docker.com/r/chiffx/discordsoundboard
The latest official dockerhub image could likely use a bump for some of the recent Java changes.